### PR TITLE
Evaluation should not be computed with gradient

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -424,8 +424,9 @@ def finetune(encoder, mlp, dataloaders, args):
             args.writer.add_scalars(
                 'finetune_lr', {'train': optimiser.param_groups[0]['lr']}, epoch+1)
 
-        valid_loss, valid_acc, valid_acc_top5 = evaluate(
-            encoder, mlp, dataloaders, 'valid', epoch, args)
+        with torch.no_grad():
+            valid_loss, valid_acc, valid_acc_top5 = evaluate(
+                encoder, mlp, dataloaders, 'valid', epoch, args)
 
         # For the best performing epoch, reset patience and save model,
         # else update patience.


### PR DESCRIPTION
In the original implementation, the evaluation is performed with gradients when finetuning. This can be corrected by wrapping the evaluation in a torch.no_grad()